### PR TITLE
Keep the logo from killing the resize box on smaller screens

### DIFF
--- a/aesen.html
+++ b/aesen.html
@@ -30,6 +30,7 @@
 		background: linear-gradient(#283593, #1A237E);
 		display: table;
 		box-shadow: 0rem 2rem 8rem #000;
+		pointer-events: none;
 	}
 	.ae {
 		display: table-cell;


### PR DESCRIPTION
Could have also messed with Z-index, but this was closer to the intent.